### PR TITLE
Disable check for hashes on external links

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task :test do
   sh "bundle exec jekyll build"
   options = {
     :check_sri => true,
-    :check_external_hash => true,
+    :check_external_hash => false,
     :check_favicon => false,
     :check_html => true,
     :check_img_http => true,


### PR DESCRIPTION
This could lead to false failures for dynamically generated hashes on
links, such as with Etherpad line links.

Signed-off-by: Lars Marowsky-Bree <lmb@suse.com>