### PR TITLE
CI: HTMLProofer: disable external link checking

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ task :test do
     :check_img_http => true,
     :check_opengraph => true,
     :enforce_https => true,
+    :disable_external => true,
     :cache => {
       :timeframe => '6w'
     },


### PR DESCRIPTION
Unfortunately, GitHub Actions don't have access to the Internet.

Signed-off-by: Lars Marowsky-Bree <lmb@suse.com>